### PR TITLE
Aim 78 implement update profile image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,4 +222,7 @@ gradle-app.setting
 
 # .env
 .env
+
+# upload
+/uploads
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,macos,java,gradle,visualstudiocode,windows

--- a/src/main/java/com/example/pitching/auth/config/WebfluxSecurityConfig.java
+++ b/src/main/java/com/example/pitching/auth/config/WebfluxSecurityConfig.java
@@ -57,7 +57,7 @@ public class WebfluxSecurityConfig {
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers("/api/v1/auth/**", "/oauth2/**", "/login/oauth2/code/**").permitAll()
                         .pathMatchers("/api/**").authenticated()
-                        .anyExchange().authenticated()
+                        .anyExchange().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .authenticationSuccessHandler(oAuth2SuccessHandler)
@@ -111,7 +111,9 @@ public class WebfluxSecurityConfig {
             // OAuth2 관련 경로 추가
             if (path.startsWith("/api/v1/auth/") ||
                     path.startsWith("/oauth2/") ||
-                    path.startsWith("/login/oauth2/")) {
+                    path.startsWith("/login/oauth2/") ||
+                    !path.startsWith("/api")
+            ) {
                 return Mono.empty();
             }
 

--- a/src/main/java/com/example/pitching/auth/domain/User.java
+++ b/src/main/java/com/example/pitching/auth/domain/User.java
@@ -24,4 +24,8 @@ public class User {
     private String profileImage;
     private String password;
     private String role;
+
+    public void setProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/com/example/pitching/auth/dto/UserInfo.java
+++ b/src/main/java/com/example/pitching/auth/dto/UserInfo.java
@@ -3,5 +3,5 @@ package com.example.pitching.auth.dto;
 public record UserInfo(
         String email,
         String username,
-        String profileImage
+        String profile_image
 ) {}

--- a/src/main/java/com/example/pitching/auth/userdetails/CustomUserDetails.java
+++ b/src/main/java/com/example/pitching/auth/userdetails/CustomUserDetails.java
@@ -27,7 +27,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getUsername();
+        return user.getEmail();
     }
 
     @Override

--- a/src/main/java/com/example/pitching/user/config/WebConfig.java
+++ b/src/main/java/com/example/pitching/user/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.pitching.user.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.config.ResourceHandlerRegistry;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+@Configuration
+public class WebConfig implements WebFluxConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:./uploads/");
+    }
+}

--- a/src/main/java/com/example/pitching/user/controller/UserController.java
+++ b/src/main/java/com/example/pitching/user/controller/UserController.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 public class UserController {
     private final UserService userService;
 

--- a/src/main/java/com/example/pitching/user/controller/UserController.java
+++ b/src/main/java/com/example/pitching/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.example.pitching.user.controller;
+
+import com.example.pitching.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Mono<ResponseEntity<Map<String, String>>> updateProfileImage(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestPart("file") Mono<FilePart> file) {
+
+        return file
+                .flatMap(filePart -> userService.updateProfileImage(userDetails.getUsername(), filePart))
+                .map(imageUrl -> ResponseEntity.ok(Map.of("profileImageUrl", imageUrl)))
+                .onErrorResume(e -> Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(Map.of("error", e.getMessage()))));
+    }
+}

--- a/src/main/java/com/example/pitching/user/service/FileStorageService.java
+++ b/src/main/java/com/example/pitching/user/service/FileStorageService.java
@@ -1,0 +1,45 @@
+package com.example.pitching.user.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class FileStorageService {
+
+    @Value("${app.upload.dir}")
+    private String uploadDir;
+
+    public Mono<String> store(FilePart file) {
+        String filename = UUID.randomUUID().toString() + getExtension(file.filename());
+        Path uploadPath = Path.of(uploadDir);
+
+        return Mono.just(uploadPath)
+                .map(path -> {
+                    if (!Files.exists(path)) {
+                        try {
+                            Files.createDirectories(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException("Could not create upload directory", e);
+                        }
+                    }
+                    return path.resolve(filename);
+                })
+                .flatMap(path -> file.transferTo(path)
+                        .then(Mono.just("/uploads/" + filename)));
+    }
+
+    private String getExtension(String filename) {
+        return Optional.ofNullable(filename)
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(filename.lastIndexOf(".")))
+                .orElse("");
+    }
+}

--- a/src/main/java/com/example/pitching/user/service/FileStorageService.java
+++ b/src/main/java/com/example/pitching/user/service/FileStorageService.java
@@ -1,45 +1,163 @@
 package com.example.pitching.user.service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.stereotype.Service;
+import org.springframework.util.unit.DataSize;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.UUID;
 
 @Service
+@Slf4j
+@RequiredArgsConstructor
 public class FileStorageService {
 
     @Value("${app.upload.dir}")
     private String uploadDir;
 
-    public Mono<String> store(FilePart file) {
-        String filename = UUID.randomUUID().toString() + getExtension(file.filename());
-        Path uploadPath = Path.of(uploadDir);
+    @Value("${app.upload.max-file-size}")
+    private DataSize maxFileSize;
 
-        return Mono.just(uploadPath)
-                .map(path -> {
-                    if (!Files.exists(path)) {
-                        try {
-                            Files.createDirectories(path);
-                        } catch (IOException e) {
-                            throw new RuntimeException("Could not create upload directory", e);
-                        }
-                    }
-                    return path.resolve(filename);
-                })
-                .flatMap(path -> file.transferTo(path)
-                        .then(Mono.just("/uploads/" + filename)));
+    /**
+     * 파일을 저장하고 URL을 반환합니다.
+     * @param file 저장할 파일
+     * @return 저장된 파일의 URL
+     */
+    public Mono<String> store(FilePart file) {
+        return validateFile(file)
+                .then(generateFilePath(file))
+                .flatMap(path -> saveFile(file, path))
+                .map(this::generateFileUrl)
+                .doOnSuccess(url -> log.info("File stored successfully: {}", url))
+                .doOnError(error -> log.error("Error storing file: {}", file.filename(), error));
     }
 
-    private String getExtension(String filename) {
+    /**
+     * 파일을 삭제합니다.
+     * @param fileUrl 삭제할 파일의 URL
+     * @return 삭제 완료를 나타내는 Mono
+     */
+    public Mono<Void> delete(String fileUrl) {
+        return Mono.just(fileUrl)
+                .filter(url -> url != null && !url.isEmpty())
+                .map(this::extractFilenameFromUrl)
+                .map(filename -> Path.of(uploadDir, filename))
+                .flatMap(this::deleteFile)
+                .onErrorResume(error -> {
+                    log.error("Error deleting file: {}", fileUrl, error);
+                    return Mono.empty();
+                });
+    }
+
+    /**
+     * 파일의 유효성을 검사합니다.
+     */
+    private Mono<Void> validateFile(FilePart file) {
+        return Mono.just(file)
+                .filter(f -> {
+                    String contentType = f.headers().getContentType().toString();
+                    return contentType.startsWith("image/");
+                })
+                .switchIfEmpty(Mono.error(
+                        new IllegalArgumentException("Only image files are allowed")
+                ))
+                .filter(f -> f.headers().getContentLength() <= maxFileSize.toBytes())
+                .switchIfEmpty(Mono.error(
+                        new IllegalArgumentException("File size exceeds maximum limit of " + maxFileSize.toMegabytes() + "MB")
+                ))
+                .then();
+    }
+
+    /**
+     * 파일 저장을 위한 경로를 생성합니다.
+     */
+    private Mono<Path> generateFilePath(FilePart file) {
+        return Mono.just(file)
+                .map(FilePart::filename)
+                .map(this::generateUniqueFilename)
+                .map(filename -> createUploadPath().resolve(filename));
+    }
+
+    /**
+     * 업로드 디렉토리를 생성하고 경로를 반환합니다.
+     */
+    private Path createUploadPath() {
+        Path uploadPath = Path.of(uploadDir);
+        try {
+            Files.createDirectories(uploadPath);
+            return uploadPath;
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create upload directory", e);
+        }
+    }
+
+    /**
+     * 고유한 파일 이름을 생성합니다.
+     */
+    private String generateUniqueFilename(String originalFilename) {
+        String extension = getFileExtension(originalFilename);
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        return UUID.randomUUID().toString() + "_" + timestamp + extension;
+    }
+
+    /**
+     * 파일 확장자를 추출합니다.
+     */
+    private String getFileExtension(String filename) {
         return Optional.ofNullable(filename)
                 .filter(f -> f.contains("."))
-                .map(f -> f.substring(filename.lastIndexOf(".")))
+                .map(f -> f.substring(f.lastIndexOf(".")))
                 .orElse("");
+    }
+
+    /**
+     * 실제 파일을 저장합니다.
+     */
+    private Mono<Path> saveFile(FilePart file, Path path) {
+        return file.transferTo(path)
+                .then(Mono.just(path))
+                .doOnSuccess(__ -> log.info("File saved successfully: {}", path.getFileName()))
+                .doOnError(error -> log.error("Error saving file: {}", path.getFileName(), error));
+    }
+
+    /**
+     * 파일의 URL을 생성합니다.
+     */
+    private String generateFileUrl(Path path) {
+        return "/uploads/" + path.getFileName().toString();
+    }
+
+    /**
+     * 파일을 삭제합니다.
+     */
+    private Mono<Void> deleteFile(Path path) {
+        return Mono.fromCallable(() -> {
+                    if (Files.exists(path)) {
+                        Files.delete(path);
+                        log.info("Successfully deleted file: {}", path.getFileName());
+                        return true;
+                    }
+                    log.info("File does not exist, skipping deletion: {}", path.getFileName());
+                    return false;
+                })
+                .then();
+    }
+
+    /**
+     * URL에서 파일 이름을 추출합니다.
+     */
+    private String extractFilenameFromUrl(String fileUrl) {
+        return Optional.ofNullable(fileUrl)
+                .map(url -> url.substring(url.lastIndexOf('/') + 1))
+                .orElseThrow(() -> new IllegalArgumentException("Invalid file URL"));
     }
 }

--- a/src/main/java/com/example/pitching/user/service/UserService.java
+++ b/src/main/java/com/example/pitching/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.example.pitching.user.service;
 
 import com.example.pitching.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,19 +11,66 @@ import com.example.pitching.auth.domain.User;
 
 @Service
 @Transactional
+@Slf4j
 @RequiredArgsConstructor
 public class UserService {
-
     private final UserRepository userRepository;
     private final FileStorageService fileStorageService;
 
     public Mono<String> updateProfileImage(String email, FilePart file) {
+        return findUser(email)
+                .flatMap(user -> updateUserProfileImage(user, file));
+    }
+
+    private Mono<User> findUser(String email) {
+        return userRepository.findByEmail(email)
+                .switchIfEmpty(Mono.error(
+                        // TODO: Global exception으로 변경
+                        // new ResourceNotFoundException("User not found with email: " + email)
+                        new Error("User not found with email: " + email)
+                ));
+    }
+
+    private Mono<String> updateUserProfileImage(User user, FilePart file) {
+        return storeNewImage(file)
+                .flatMap(newImageUrl -> updateUserAndHandleOldImage(user, newImageUrl));
+    }
+
+    private Mono<String> storeNewImage(FilePart file) {
         return fileStorageService.store(file)
-                .flatMap(imageUrl -> userRepository.findByEmail(email)
-                        .flatMap(user -> {
-                            user.setProfileImage(imageUrl);
-                            return userRepository.save(user);
-                        })
-                        .map(User::getProfileImage));
+                .onErrorResume(error -> Mono.error(
+                        // TODO: Global exception으로 변경
+                        // new ImageProcessingException("Failed to store new profile image", error)
+                        new Error("Failed to store new profile image", error)
+                ));
+    }
+
+    private Mono<String> updateUserAndHandleOldImage(User user, String newImageUrl) {
+        return Mono.just(user.getProfileImage())
+                .flatMap(oldImageUrl -> {
+                    if (oldImageUrl != null && !oldImageUrl.isEmpty()) {
+                        return updateUserImage(user, newImageUrl)
+                                .doOnSuccess(__ -> deleteOldImage(oldImageUrl));
+                    }
+                    return updateUserImage(user, newImageUrl);
+                });
+    }
+
+    private Mono<String> updateUserImage(User user, String newImageUrl) {
+        return Mono.just(user)
+                .map(u -> {
+                    u.setProfileImage(newImageUrl);
+                    return u;
+                })
+                .flatMap(userRepository::save)
+                .map(User::getProfileImage)
+                .doOnSuccess(__ -> log.info("Updated profile image for user: {}", user.getEmail()));
+    }
+
+    private void deleteOldImage(String imageUrl) {
+        fileStorageService.delete(imageUrl)
+                .doOnSuccess(__ -> log.info("Successfully deleted old profile image: {}", imageUrl))
+                .doOnError(error -> log.error("Failed to delete old profile image: {}", imageUrl, error))
+                .subscribe();
     }
 }

--- a/src/main/java/com/example/pitching/user/service/UserService.java
+++ b/src/main/java/com/example/pitching/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.example.pitching.user.service;
+
+import com.example.pitching.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+import com.example.pitching.auth.domain.User;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final FileStorageService fileStorageService;
+
+    public Mono<String> updateProfileImage(String email, FilePart file) {
+        return fileStorageService.store(file)
+                .flatMap(imageUrl -> userRepository.findByEmail(email)
+                        .flatMap(user -> {
+                            user.setProfileImage(imageUrl);
+                            return userRepository.save(user);
+                        })
+                        .map(User::getProfileImage));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,10 +44,6 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-    webflux:
-      multipart:
-        max-file-size: 5MB
-        max-request-size: 5MB
 
 jwt:
   secret: ${JWT_SECRET_KEY}
@@ -62,7 +58,7 @@ front:
 app:
   upload:
     dir: ./uploads
-    max-file-size: 5MB  # FileStorageService에서 사용할 제한
+    max-file-size: 5MB  # FileStorageService에서 사용할 제한 : 5MB
 ---
 # local
 redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ front:
 app:
   upload:
     dir: ./uploads
-    max-file-size: 5MB  # FileStorageService에서 사용할 제한 : 5MB
+    max-file-size: 2MB  # FileStorageService에서 사용할 제한 : 2MB
 ---
 # local
 redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ front:
 app:
   upload:
     dir: ./uploads
-    max-file-size: 2MB  # FileStorageService에서 사용할 제한 : 2MB
+    max-file-size: 2MB
 ---
 # local
 redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,10 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+    webflux:
+      multipart:
+        max-file-size: 5MB
+        max-request-size: 5MB
 
 jwt:
   secret: ${JWT_SECRET_KEY}
@@ -54,6 +58,11 @@ jwt:
 
 front:
   url: ${FRONT_URL}
+
+app:
+  upload:
+    dir: ./uploads
+    max-file-size: 5MB  # FileStorageService에서 사용할 제한
 ---
 # local
 redis:


### PR DESCRIPTION
# ☝️Issue Number

- #14 

# 🔎 Key Changes
- profile image를 변경하는 로직 생성
- 이미지는 파일로 저장하고 `/uploads`에 저장하도록 했어요.
- profile_image에는 해당 directory의 파일 경로를 저장해요.
- 이미지 파일은 최대 2MB로 설정했어요. (4k 이미지의 경우 2MB를 넘지 않기때문에, 2MB가 적당하다고 생각했어요.)
- 해당 파일은 git에 올리지 않아야하기 때문에, gitIgnore에 추가했어요.
- 파일 경로에 대한 접근은 허용해야하기 때문에, `/api` 경로외의 접근은 permitall 해줬어요.
- 한 유저당 하나의 profile image만 가질 수 있기때문에, update시 기존 이미지는 삭제하도록 했어요.


# 💌 To Reviewers
- 주의사항
