### PR TITLE
AIM-169 add: test coverage with jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.4'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'jacoco'
 }
 
 group = 'com.example'
@@ -55,6 +56,61 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
-tasks.named('test') {
+jacoco {
+	toolVersion = "0.8.11"  // 최신 버전으로 업데이트
+}
+
+test {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		csv.required = false
+		html.required = true
+		html.outputLocation = layout.buildDirectory.dir('reports/jacoco')
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					"**/PitchingApplication.class",
+					"**/call/**",
+					"**/*Exception.class"
+			])
+		}))
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			element = 'CLASS'
+
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.70
+			}
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.70
+			}
+
+			excludes = [
+					'com.example.pitching.PitchingApplication',
+					'com.example.pitching.call.*',
+					'**.*Exception'
+			]
+		}
+	}
+}
+
+tasks.named('check') {
+	dependsOn jacocoTestCoverageVerification
 }


### PR DESCRIPTION
# ☝️Issue Number

- #35 

# 🔎 Key Changes
- test coverage 추가 with jacocoo (선택 이유 : [링크](https://quaint-soprano-826.notion.site/Test-coverage-c2a0f2631e4e43f18d9af1e39dcd96fa?pvs=4))

사용방법
1. 터미널에 명령어 입력
```
./gradlew test jacocoTestReport
````
2. build/reports/index.html 확인
<img width="1149" alt="스크린샷 2024-12-05 오후 2 44 29" src="https://github.com/user-attachments/assets/6d2b469d-c244-486b-b676-9b0769e7e238">


### Reference
- https://docs.gradle.org/current/userguide/jacoco_plugin.html

# 💌 To Reviewers
- 주의사항
