### PR TITLE
Aim 178 add user data

### DIFF
--- a/src/main/java/com/example/pitching/auth/domain/User.java
+++ b/src/main/java/com/example/pitching/auth/domain/User.java
@@ -16,12 +16,11 @@ import java.util.List;
 @NoArgsConstructor
 public class User {
     @Id
-    @Column("user_id")
-    private Long userId;
-
     private String email;
     @Setter
     private String username;
+    @Column("user_id")
+    private Long userId;
     @Setter
     @Column("profile_image")
     private String profileImage;
@@ -33,6 +32,11 @@ public class User {
 
     public static User createNewUser(String email, String username,
                                      String profileImage, String password) {
-        return new User(null, email, username, profileImage, password, "USER", new ArrayList<>());
+        return new User(email, username, null, profileImage, password, "USER", new ArrayList<>());
+    }
+
+    public static User createNewUser(String email, String username,
+                                     String profileImage, String password, Long userId) {
+        return new User(email, username, userId, profileImage, password, "USER", new ArrayList<>());
     }
 }

--- a/src/main/java/com/example/pitching/auth/domain/User.java
+++ b/src/main/java/com/example/pitching/auth/domain/User.java
@@ -16,6 +16,9 @@ import java.util.List;
 @NoArgsConstructor
 public class User {
     @Id
+    @Column("user_id")
+    private Long userId;
+
     private String email;
     @Setter
     private String username;
@@ -30,6 +33,6 @@ public class User {
 
     public static User createNewUser(String email, String username,
                                      String profileImage, String password) {
-        return new User(email, username, profileImage, password, "USER", new ArrayList<>());
+        return new User(null, email, username, profileImage, password, "USER", new ArrayList<>());
     }
 }

--- a/src/main/java/com/example/pitching/auth/dto/UserInfo.java
+++ b/src/main/java/com/example/pitching/auth/dto/UserInfo.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record UserInfo(
         String email,
         String username,
+        Long userId,
         String profile_image,
         List<ServerInfo> servers
 ) {}

--- a/src/main/java/com/example/pitching/auth/repository/UserRepository.java
+++ b/src/main/java/com/example/pitching/auth/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends ReactiveCrudRepository<User, String> {
     Mono<Boolean> existsByEmail(String email);
     @Query("INSERT INTO users (email, username, password, role) VALUES (:email, :username, :password, :role)")
     Mono<Void> insertUser(String email, String username, String password, String role);
+    @Query("INSERT INTO users (email, username, password, role) VALUES (:email, :username, :password, :role) RETURNING user_id")
+    Mono<Long> insertUserAndGetId(String email, String username, String password, String role);
 }

--- a/src/main/java/com/example/pitching/auth/service/AuthService.java
+++ b/src/main/java/com/example/pitching/auth/service/AuthService.java
@@ -45,6 +45,7 @@ public class AuthService {
                                 new UserInfo(
                                         user.getEmail(),
                                         user.getUsername(),
+                                        user.getUserId(),
                                         user.getProfileImage(),
                                         servers
                                 )

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(100) PRIMARY KEY,
     username VARCHAR(50) NOT NULL,
     profile_image VARCHAR(100),
+    user_id SERIAL,
     password VARCHAR(100),
     role VARCHAR(20) NOT NULL
     );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,9 +1,15 @@
+-- 필요 시 사용
+--DROP TABLE IF EXISTS user_server_memberships;
+--DROP TABLE IF EXISTS channels;
+--DROP TABLE IF EXISTS servers;
+--DROP TABLE IF EXISTS users;
+
 -- users 테이블 생성
 CREATE TABLE IF NOT EXISTS users (
-    user_id BIGSERIAL PRIMARY KEY,
-    email VARCHAR(100) UNIQUE NOT NULL,
+    email VARCHAR(100) PRIMARY KEY,
     username VARCHAR(50) NOT NULL,
     profile_image VARCHAR(100),
+    user_id BIGSERIAL,
     password VARCHAR(100),
     role VARCHAR(20) NOT NULL
     );
@@ -15,12 +21,11 @@ CREATE TABLE IF NOT EXISTS servers (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
 
-
 CREATE TABLE IF NOT EXISTS user_server_memberships (
-    user_id BIGINT REFERENCES users(user_id),
+    email VARCHAR(100) REFERENCES users(email),
     server_id BIGINT REFERENCES servers(server_id),
     joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (user_id, server_id)
+    PRIMARY KEY (email, server_id)
     );
 
 -- channels 테이블 재정의 (ENUM 대신 VARCHAR 사용)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,9 +1,9 @@
 -- users 테이블 생성
 CREATE TABLE IF NOT EXISTS users (
-    email VARCHAR(100) PRIMARY KEY,
+    user_id BIGSERIAL PRIMARY KEY,
+    email VARCHAR(100) UNIQUE NOT NULL,
     username VARCHAR(50) NOT NULL,
     profile_image VARCHAR(100),
-    user_id SERIAL,
     password VARCHAR(100),
     role VARCHAR(20) NOT NULL
     );
@@ -15,11 +15,12 @@ CREATE TABLE IF NOT EXISTS servers (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
 
+
 CREATE TABLE IF NOT EXISTS user_server_memberships (
-    email VARCHAR(100) REFERENCES users(email),
+    user_id BIGINT REFERENCES users(user_id),
     server_id BIGINT REFERENCES servers(server_id),
     joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (email, server_id)
+    PRIMARY KEY (user_id, server_id)
     );
 
 -- channels 테이블 재정의 (ENUM 대신 VARCHAR 사용)

--- a/src/test/java/com/example/pitching/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/pitching/auth/controller/AuthControllerTest.java
@@ -33,6 +33,7 @@ class AuthControllerTest {
     private static final String TEST_PROFILE_IMAGE = "profile.jpg";
     private static final String TEST_ACCESS_TOKEN = "accessToken123";
     private static final String TEST_REFRESH_TOKEN = "refreshToken123";
+    private static final Long TEST_USER_ID = 1L;
 
     @Autowired
     private WebTestClient webTestClient;
@@ -68,7 +69,7 @@ class AuthControllerTest {
         return new UserInfo(
                 email,
                 username,
-                null,
+                TEST_USER_ID,
                 profileImage,
                 Collections.emptyList()
         );
@@ -216,5 +217,41 @@ class AuthControllerTest {
         // when & then
         performPost("/signup", invalidRequest)
                 .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("로그인 응답에 userId가 포함되어 있다")
+    void loginResponseContainsUserId() {
+        // given
+        given(authService.authenticate(anyString(), anyString()))
+                .willReturn(Mono.just(loginResponse));
+
+        // when & then
+        performPost("/login", loginRequest)
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.userInfo.userId").isEqualTo(TEST_USER_ID);
+    }
+
+    @Test
+    @DisplayName("회원가입 후 로그인 시 동일한 userId를 반환한다")
+    void signupAndLoginReturnSameUserId() {
+        // given
+        given(authService.signup(any(SignupRequest.class)))
+                .willReturn(Mono.empty());
+
+        given(authService.authenticate(TEST_EMAIL, TEST_PASSWORD))
+                .willReturn(Mono.just(loginResponse));
+
+        // when & then
+        // 1. 회원가입
+        performPost("/signup", signupRequest)
+                .expectStatus().isCreated();
+
+        // 2. 로그인하여 userId 확인
+        performPost("/login", loginRequest)
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.userInfo.userId").isEqualTo(TEST_USER_ID);
     }
 }

--- a/src/test/java/com/example/pitching/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/pitching/auth/controller/AuthControllerTest.java
@@ -68,6 +68,7 @@ class AuthControllerTest {
         return new UserInfo(
                 email,
                 username,
+                null,
                 profileImage,
                 Collections.emptyList()
         );

--- a/src/test/java/com/example/pitching/user/repository/UserServerMembershipRepositoryTest.java
+++ b/src/test/java/com/example/pitching/user/repository/UserServerMembershipRepositoryTest.java
@@ -37,7 +37,7 @@ class UserServerMembershipRepositoryTest {
         databaseClient.sql("DELETE FROM users").fetch().rowsUpdated().block();
 
         // 테스트용 사용자 생성
-        databaseClient.sql("INSERT INTO users (email, username, role) VALUES ($1, $2, $3)")
+        databaseClient.sql("INSERT INTO users (email, username, role, user_id) VALUES ($1, $2, $3, DEFAULT)")
                 .bind(0, TEST_EMAIL)
                 .bind(1, "Test User")
                 .bind(2, "USER")
@@ -108,7 +108,7 @@ class UserServerMembershipRepositoryTest {
     private void createMembership(Long serverId, String email) {
         // 사용자가 없는 경우 생성
         if (!email.equals(TEST_EMAIL)) {
-            databaseClient.sql("INSERT INTO users (email, username, role) VALUES ($1, $2, $3)")
+            databaseClient.sql("INSERT INTO users (email, username, role, user_id) VALUES ($1, $2, $3, DEFAULT)")
                     .bind(0, email)
                     .bind(1, "Test User")
                     .bind(2, "USER")

--- a/src/test/resources/chema-test.sql
+++ b/src/test/resources/chema-test.sql
@@ -1,21 +1,22 @@
 -- users 테이블 생성
 CREATE TABLE IF NOT EXISTS users (
-                                     email VARCHAR(100) PRIMARY KEY,
+    email VARCHAR(100) PRIMARY KEY,
     username VARCHAR(50) NOT NULL,
     profile_image VARCHAR(100),
+    user_id BIGSERIAL,
     password VARCHAR(100),
     role VARCHAR(20)
     );
 
 CREATE TABLE IF NOT EXISTS servers (
-                                       server_id SERIAL PRIMARY KEY,
-                                       server_name VARCHAR(100) NOT NULL,
+    server_id SERIAL PRIMARY KEY,
+    server_name VARCHAR(100) NOT NULL,
     server_image VARCHAR(100),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
 
 CREATE TABLE IF NOT EXISTS user_server_memberships (
-                                                       email VARCHAR(100) REFERENCES users(email),
+    email VARCHAR(100) REFERENCES users(email),
     server_id BIGINT REFERENCES servers(server_id),
     joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (email, server_id)


### PR DESCRIPTION
# ☝️Issue Number

- #42 

# 🔎 Key Changes
- user data안에 userId값을 추가했습니다.
- schema.sql에 추가하여 자동으로 db에 추가됩니다. (기존 db가 있다면, 삭제 해야하기 때문에 주석 처리한 drop table 부분을 지우고 실행해주세요)
- 기본 로그인, 간편 로그인 모두 userId를 자동으로 increment해서 응답합니다.
- 관련된 test code도 추가했습니다.

# 💌 To Reviewers
- user_id를 pk값으로 변경하려고 했지만, 아래와 같은 이유로 column값으로만 추가했습니다.
``` markdown
1. 기존에 pk값을 email로 해서 변경하기에 꼬여있는 로직들이 많았다.
2. server에서 유저를 초대할 때, server id와 초대하는 유저의 email을 포함하여 요청하는데, email이 pk값이면 추가하기 용이하다.
```
