### PR TITLE
Aim 201 apply rabbit mq redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ dependencies {
 	// s3
 	implementation 'software.amazon.awssdk:s3'
 
+	// rabbitmq
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation 'io.projectreactor.rabbitmq:reactor-rabbitmq:1.5.6'
+
 	implementation("org.springframework:spring-websocket")
 }
 

--- a/src/main/java/com/example/pitching/chat/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/pitching/chat/config/RabbitMQConfig.java
@@ -10,8 +10,8 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RabbitMQConfig {
-    public static final String CHAT_QUEUE = "chat.queue.v2"; // 새로운 큐 이름
-    public static final String CHAT_EXCHANGE = "chat.exchange.v2"; // 새로운 exchange 이름
+    public static final String CHAT_QUEUE = "chat.queue.v2";
+    public static final String CHAT_EXCHANGE = "chat.exchange.v2";
     public static final String CHAT_ROUTING_KEY = "chat.routing.#";
 
     @Bean

--- a/src/main/java/com/example/pitching/chat/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/pitching/chat/config/RabbitMQConfig.java
@@ -1,0 +1,50 @@
+package com.example.pitching.chat.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+    public static final String CHAT_QUEUE = "chat.queue.v2"; // 새로운 큐 이름
+    public static final String CHAT_EXCHANGE = "chat.exchange.v2"; // 새로운 exchange 이름
+    public static final String CHAT_ROUTING_KEY = "chat.routing.#";
+
+    @Bean
+    public Queue chatQueue() {
+        return QueueBuilder.durable(CHAT_QUEUE)
+                .withArgument("x-max-length", 100)
+                .withArgument("x-overflow", "drop-head")
+                .withArgument("x-message-ttl", 86400000)
+                .build();
+    }
+
+    @Bean
+    public TopicExchange chatExchange() {
+        return new TopicExchange(CHAT_EXCHANGE);
+    }
+
+    @Bean
+    public Binding chatBinding(Queue chatQueue, TopicExchange chatExchange) {
+        return BindingBuilder.bind(chatQueue)
+                .to(chatExchange)
+                .with(CHAT_ROUTING_KEY);
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter messageConverter(ObjectMapper objectMapper) {
+        return new Jackson2JsonMessageConverter(objectMapper);
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                         Jackson2JsonMessageConverter messageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(messageConverter);
+        return template;
+    }
+}

--- a/src/main/java/com/example/pitching/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/com/example/pitching/chat/handler/ChatWebSocketHandler.java
@@ -96,11 +96,10 @@ public class ChatWebSocketHandler implements WebSocketHandler {
         ChatMessage chatMessage = command.getPayload().toChatMessage();
 
         return chatService.saveTalkMessage(
-                        chatMessage.getChannelId(),
-                        chatMessage.getSender(),
-                        chatMessage.getMessage()
-                )
-                .flatMap(messageDTO -> broadcastToChannel(messageDTO.getChannelId(), messageDTO));
+                chatMessage.getChannelId(),
+                chatMessage.getSender(),
+                chatMessage.getMessage()
+        ).then();
     }
 
     private Mono<Void> handleUnsubscribe(WebSocketSession session) {
@@ -146,7 +145,7 @@ public class ChatWebSocketHandler implements WebSocketHandler {
         }
     }
 
-    private Mono<Void> broadcastToChannel(Long channelId, ChatMessageDTO messageDTO) {
+    public Mono<Void> broadcastToChannel(Long channelId, ChatMessageDTO messageDTO) {
         Map<String, WebSocketSession> sessions = channelSubscriptions.get(channelId);
         if (sessions == null || sessions.isEmpty()) {
             return Mono.empty();

--- a/src/main/java/com/example/pitching/chat/repository/ChatRedisRepository.java
+++ b/src/main/java/com/example/pitching/chat/repository/ChatRedisRepository.java
@@ -1,0 +1,56 @@
+package com.example.pitching.chat.repository;
+
+import com.example.pitching.chat.dto.ChatMessageDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ChatRedisRepository {
+    private final ReactiveStringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String KEY_PREFIX = "chat:messages:";
+
+    public Mono<Boolean> saveMessage(ChatMessageDTO message) {
+        try {
+            String key = KEY_PREFIX + message.getChannelId();
+            String value = objectMapper.writeValueAsString(message);
+            return redisTemplate.opsForList().rightPush(key, value)
+                    .flatMap(length -> {
+                        if (length > 100) {
+                            return redisTemplate.opsForList().leftPop(key)
+                                    .thenReturn(true);
+                        }
+                        return Mono.just(true);
+                    })
+                    .doOnError(e -> log.error("Error saving message to Redis: {}", e.getMessage()));
+        } catch (JsonProcessingException e) {
+            return Mono.error(e);
+        }
+    }
+
+    public Flux<ChatMessageDTO> getRecentMessages(Long channelId) {
+        String key = KEY_PREFIX + channelId;
+        return redisTemplate.opsForList().range(key, 0, -1)
+                .map(json -> {
+                    try {
+                        return objectMapper.readValue(json, ChatMessageDTO.class);
+                    } catch (JsonProcessingException e) {
+                        log.error("Error deserializing message: {}", e.getMessage());
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    public Mono<Boolean> deleteChannelMessages(Long channelId) {
+        String key = KEY_PREFIX + channelId;
+        return redisTemplate.delete(key).hasElement();
+    }
+}

--- a/src/main/java/com/example/pitching/chat/service/ChatMessageProcessor.java
+++ b/src/main/java/com/example/pitching/chat/service/ChatMessageProcessor.java
@@ -1,0 +1,36 @@
+package com.example.pitching.chat.service;
+
+import com.example.pitching.chat.config.RabbitMQConfig;
+import com.example.pitching.chat.dto.ChatMessageDTO;
+import com.example.pitching.chat.handler.ChatWebSocketHandler;
+import com.example.pitching.chat.repository.ChatRedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessageProcessor {
+    private final ChatService chatService;
+    private final ChatRedisRepository chatRedisRepository;
+    private final ChatWebSocketHandler webSocketHandler;
+
+    @RabbitListener(queues = RabbitMQConfig.CHAT_QUEUE)
+    public void processMessage(ChatMessageDTO message) {
+        log.info("Received message from queue: {}", message.getMessageId());
+
+        // Save to DynamoDB
+        Mono.just(message)
+                .flatMap(msg -> chatService.saveMessageToDynamoDB(msg))
+                // Save to Redis
+                .flatMap(chatRedisRepository::saveMessage)
+                // Broadcast to WebSocket
+                .flatMap(saved -> webSocketHandler.broadcastToChannel(
+                        message.getChannelId(), message))
+                .doOnError(e -> log.error("Error processing message: {}", e.getMessage()))
+                .subscribe();
+    }
+}

--- a/src/main/java/com/example/pitching/chat/service/ChatService.java
+++ b/src/main/java/com/example/pitching/chat/service/ChatService.java
@@ -47,7 +47,17 @@ public class ChatService {
                 messageDTO.getSender(),
                 messageDTO.getMessage()
         );
+
+        log.info("Attempting to save ChatMessage to DynamoDB: channelId={}, messageId={}",
+                chatMessage.getChannelId(), chatMessage.getMessageId());
+
         return chatRepository.save(chatMessage)
+                .doOnSuccess(savedMessage ->
+                        log.info("Successfully saved message to DynamoDB: messageId={}",
+                                savedMessage.getMessageId()))
+                .doOnError(e ->
+                        log.error("Failed to save message to DynamoDB: messageId={}, error={}",
+                                chatMessage.getMessageId(), e.getMessage(), e))
                 .thenReturn(messageDTO);
     }
 

--- a/src/main/java/com/example/pitching/chat/service/ChatService.java
+++ b/src/main/java/com/example/pitching/chat/service/ChatService.java
@@ -1,13 +1,15 @@
 package com.example.pitching.chat.service;
 
 import com.example.pitching.auth.domain.User;
+import com.example.pitching.chat.config.RabbitMQConfig;
 import com.example.pitching.chat.domain.ChatMessage;
-import com.example.pitching.chat.dto.UserUpdateMessage;
 import com.example.pitching.chat.dto.ChatMessageDTO;
 import com.example.pitching.chat.repository.ChatRepository;
+import com.example.pitching.chat.repository.ChatRedisRepository;
 import com.example.pitching.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -17,51 +19,56 @@ import reactor.core.publisher.Mono;
 @Slf4j
 public class ChatService {
     private final ChatRepository chatRepository;
+    private final ChatRedisRepository chatRedisRepository;
     private final UserRepository userRepository;
+    private final RabbitTemplate rabbitTemplate;
 
     public Mono<ChatMessageDTO> saveTalkMessage(Long channelId, String sender, String message) {
         ChatMessage chatMessage = ChatMessage.createTalkMessage(channelId, sender, message);
-        return chatRepository.save(chatMessage)
-                .flatMap(savedMessage -> userRepository.findById(sender)
-                        .map(user -> ChatMessageDTO.from(savedMessage, user)))
-                .doOnSuccess(saved -> log.info("Saved message: {} for channel: {}", saved.getMessageId(), channelId))
-                .doOnError(e -> log.error("Error saving message for channel {}: {}", channelId, e.getMessage()));
+        return userRepository.findById(sender)
+                .map(user -> ChatMessageDTO.from(chatMessage, user))
+                .doOnNext(messageDTO -> {
+                    rabbitTemplate.convertAndSend(
+                            RabbitMQConfig.CHAT_EXCHANGE,
+                            RabbitMQConfig.CHAT_ROUTING_KEY,
+                            messageDTO
+                    );
+                })
+                .doOnSuccess(saved -> log.info("Message sent to queue: {}", saved.getMessageId()))
+                .doOnError(e -> log.error("Error sending message to queue: {}", e.getMessage()));
     }
 
-    public Mono<ChatMessageDTO> createEnterMessage(Long channelId, String sender) {
-        ChatMessage chatMessage = ChatMessage.createEnterMessage(channelId, sender);
+    public Mono<ChatMessageDTO> saveMessageToDynamoDB(ChatMessageDTO messageDTO) {
+        ChatMessage chatMessage = new ChatMessage(
+                messageDTO.getChannelId(),
+                messageDTO.getTimestamp(),
+                messageDTO.getMessageId(),
+                messageDTO.getType(),
+                messageDTO.getSender(),
+                messageDTO.getMessage()
+        );
         return chatRepository.save(chatMessage)
-                .flatMap(savedMessage -> userRepository.findById(sender)
-                        .map(user -> ChatMessageDTO.from(savedMessage, user)))
-                .doOnSuccess(saved -> log.info("Saved enter message for channel: {}", channelId))
-                .doOnError(e -> log.error("Error saving enter message for channel {}: {}", channelId, e.getMessage()));
-    }
-
-    public Mono<ChatMessageDTO> createLeaveMessage(Long channelId, String sender) {
-        ChatMessage chatMessage = ChatMessage.createLeaveMessage(channelId, sender);
-        return chatRepository.save(chatMessage)
-                .flatMap(savedMessage -> userRepository.findById(sender)
-                        .map(user -> ChatMessageDTO.from(savedMessage, user)))
-                .doOnSuccess(saved -> log.info("Saved leave message for channel: {}", channelId))
-                .doOnError(e -> log.error("Error saving leave message for channel {}: {}", channelId, e.getMessage()));
+                .thenReturn(messageDTO);
     }
 
     public Flux<ChatMessageDTO> getChannelMessages(Long channelId) {
-        if (channelId == null) {
-            return Flux.error(new IllegalArgumentException("Channel ID cannot be null"));
-        }
-
-        return chatRepository.findByChannelIdOrderByTimestampAsc(channelId)
-                .flatMap(message -> userRepository.findById(message.getSender())
-                        .map(user -> ChatMessageDTO.from(message, user)))
-                .doOnSubscribe(s -> log.info("Starting to fetch messages for channel: {}", channelId))
+        return chatRedisRepository.getRecentMessages(channelId)
+                .switchIfEmpty(
+                        chatRepository.findByChannelIdOrderByTimestampAsc(channelId)
+                                .flatMap(message -> userRepository.findById(message.getSender())
+                                        .map(user -> ChatMessageDTO.from(message, user)))
+                                .flatMap(msg -> chatRedisRepository.saveMessage(msg).thenReturn(msg))
+                )
+                .doOnSubscribe(s -> log.info("Fetching messages for channel: {}", channelId))
                 .doOnComplete(() -> log.info("Completed fetching messages for channel: {}", channelId))
                 .doOnError(e -> log.error("Error fetching messages for channel {}: {}", channelId, e.getMessage()));
     }
 
     public Mono<Void> deleteChannelMessages(Long channelId) {
-        return chatRepository.deleteByChannelId(channelId)
-                .doOnSuccess(v -> log.info("Deleted all messages for channel: {}", channelId))
+        return Mono.when(
+                        chatRepository.deleteByChannelId(channelId),
+                        chatRedisRepository.deleteChannelMessages(channelId)
+                ).doOnSuccess(v -> log.info("Deleted all messages for channel: {}", channelId))
                 .doOnError(e -> log.error("Error deleting messages for channel {}: {}", channelId, e.getMessage()));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,7 +111,12 @@ spring:
     url: ${LOCAL_POSTGRESQL_URL}
     username: ${LOCAL_POSTGRESQL_USERNAME}
     password: ${LOCAL_POSTGRESQL_PASSWORD}
-
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: ${LOCAL_RABBITMQ_USERNAME}
+    password: ${LOCAL_RABBITMQ_PASSWORD}
+    connection-timeout: 10000
 logging:
   level:
     org.springframework.r2dbc: DEBUG
@@ -127,7 +132,12 @@ spring:
     url: ${PROD_POSTGRESQL_URL}
     username: ${PROD_POSTGRESQL_USERNAME}
     password: ${PROD_POSTGRESQL_PASSWORD}
-
+  rabbitmq:
+    host: ${PROD_RABBITMQ_HOST}
+    port: 5672
+    username: ${PROD_RABBITMQ_USERNAME}
+    password: ${PROD_RABBITMQ_PASSWORD}
+    connection-timeout: 10000
 redis:
   host: ${PROD_REDIS_HOST}
   port: ${PROD_REDIS_PORT:6379}

--- a/src/test/java/com/example/pitching/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/example/pitching/chat/service/ChatServiceTest.java
@@ -1,8 +1,10 @@
 package com.example.pitching.chat.service;
 
+import com.example.pitching.chat.config.RabbitMQConfig;
 import com.example.pitching.chat.domain.ChatMessage;
 import com.example.pitching.chat.dto.ChatMessageDTO;
 import com.example.pitching.chat.repository.ChatRepository;
+import com.example.pitching.chat.repository.ChatRedisRepository;
 import com.example.pitching.auth.repository.UserRepository;
 import com.example.pitching.auth.domain.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,12 +13,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ActiveProfiles("test")
@@ -27,13 +31,20 @@ class ChatServiceTest {
     private ChatRepository chatRepository;
 
     @Mock
+    private ChatRedisRepository chatRedisRepository;
+
+    @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
 
     @InjectMocks
     private ChatService chatService;
 
     private ChatMessage sampleChatMessage;
     private User sampleUser;
+    private ChatMessageDTO sampleMessageDTO;
     private final Long channelId = 1L;
     private final String sender = "test@example.com";
     private final String username = "Test User";
@@ -46,14 +57,18 @@ class ChatServiceTest {
                 channelId, sender, message
         );
         sampleUser = User.createNewUser(sender, username, profileImage, "password");
+        sampleMessageDTO = ChatMessageDTO.from(sampleChatMessage, sampleUser);
     }
 
     @Test
     void saveTalkMessage_Success() {
-        when(chatRepository.save(any(ChatMessage.class)))
-                .thenReturn(Mono.just(sampleChatMessage));
         when(userRepository.findById(sender))
                 .thenReturn(Mono.just(sampleUser));
+        doNothing().when(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.CHAT_EXCHANGE),
+                eq(RabbitMQConfig.CHAT_ROUTING_KEY),
+                any(ChatMessageDTO.class)
+        );
 
         StepVerifier.create(chatService.saveTalkMessage(channelId, sender, message))
                 .expectNextMatches(dto -> {
@@ -61,8 +76,12 @@ class ChatServiceTest {
                             dto.getProfile_image().equals(profileImage) &&
                             dto.getSenderName().equals(username);
                     if (matches) {
-                        verify(chatRepository, times(1)).save(any(ChatMessage.class));
                         verify(userRepository, times(1)).findById(sender);
+                        verify(rabbitTemplate, times(1)).convertAndSend(
+                                eq(RabbitMQConfig.CHAT_EXCHANGE),
+                                eq(RabbitMQConfig.CHAT_ROUTING_KEY),
+                                any(ChatMessageDTO.class)
+                        );
                     }
                     return matches;
                 })
@@ -70,43 +89,16 @@ class ChatServiceTest {
     }
 
     @Test
-    void createEnterMessage_Success() {
-        ChatMessage enterMessage = ChatMessage.createEnterMessage(channelId, sender);
+    void saveMessageToDynamoDB_Success() {
         when(chatRepository.save(any(ChatMessage.class)))
-                .thenReturn(Mono.just(enterMessage));
-        when(userRepository.findById(sender))
-                .thenReturn(Mono.just(sampleUser));
+                .thenReturn(Mono.just(sampleChatMessage));
 
-        StepVerifier.create(chatService.createEnterMessage(channelId, sender))
+        StepVerifier.create(chatService.saveMessageToDynamoDB(sampleMessageDTO))
                 .expectNextMatches(dto -> {
-                    boolean matches = dto.getMessage().equals(username + "님이 입장하셨습니다.") &&
-                            dto.getProfile_image().equals(profileImage) &&
-                            dto.getSenderName().equals(username);
+                    boolean matches = dto.getMessage().equals(message) &&
+                            dto.getChannelId().equals(channelId);
                     if (matches) {
                         verify(chatRepository, times(1)).save(any(ChatMessage.class));
-                        verify(userRepository, times(1)).findById(sender);
-                    }
-                    return matches;
-                })
-                .verifyComplete();
-    }
-
-    @Test
-    void createLeaveMessage_Success() {
-        ChatMessage leaveMessage = ChatMessage.createLeaveMessage(channelId, sender);
-        when(chatRepository.save(any(ChatMessage.class)))
-                .thenReturn(Mono.just(leaveMessage));
-        when(userRepository.findById(sender))
-                .thenReturn(Mono.just(sampleUser));
-
-        StepVerifier.create(chatService.createLeaveMessage(channelId, sender))
-                .expectNextMatches(dto -> {
-                    boolean matches = dto.getMessage().equals(username + "님이 퇴장하셨습니다.") &&
-                            dto.getProfile_image().equals(profileImage) &&
-                            dto.getSenderName().equals(username);
-                    if (matches) {
-                        verify(chatRepository, times(1)).save(any(ChatMessage.class));
-                        verify(userRepository, times(1)).findById(sender);
                     }
                     return matches;
                 })
@@ -115,10 +107,14 @@ class ChatServiceTest {
 
     @Test
     void getChannelMessages_Success() {
+        when(chatRedisRepository.getRecentMessages(channelId))
+                .thenReturn(Flux.empty());
         when(chatRepository.findByChannelIdOrderByTimestampAsc(channelId))
                 .thenReturn(Flux.just(sampleChatMessage));
         when(userRepository.findById(sender))
                 .thenReturn(Mono.just(sampleUser));
+        when(chatRedisRepository.saveMessage(any(ChatMessageDTO.class)))
+                .thenReturn(Mono.empty());
 
         StepVerifier.create(chatService.getChannelMessages(channelId))
                 .expectNextMatches(dto -> {
@@ -137,23 +133,28 @@ class ChatServiceTest {
 
     @Test
     void getChannelMessages_WithNullChannelId() {
-        StepVerifier.create(chatService.getChannelMessages(null))
-                .expectError(IllegalArgumentException.class)
-                .verify();
+        when(chatRepository.findByChannelIdOrderByTimestampAsc(null))
+                .thenReturn(Flux.empty());
 
-        verify(chatRepository, never())
-                .findByChannelIdOrderByTimestampAsc(any());
+        when(chatRedisRepository.getRecentMessages(null))
+                .thenReturn(Flux.empty());
+
+        StepVerifier.create(chatService.getChannelMessages(null))
+                .verifyComplete();
     }
 
     @Test
     void deleteChannelMessages_Success() {
         when(chatRepository.deleteByChannelId(channelId))
                 .thenReturn(Mono.empty());
+        when(chatRedisRepository.deleteChannelMessages(channelId))
+                .thenReturn(Mono.empty());
 
         StepVerifier.create(chatService.deleteChannelMessages(channelId))
                 .verifyComplete();
 
         verify(chatRepository, times(1)).deleteByChannelId(channelId);
+        verify(chatRedisRepository, times(1)).deleteChannelMessages(channelId);
     }
 
     @Test
@@ -161,11 +162,14 @@ class ChatServiceTest {
         RuntimeException expectedException = new RuntimeException("Delete Error");
         when(chatRepository.deleteByChannelId(channelId))
                 .thenReturn(Mono.error(expectedException));
+        when(chatRedisRepository.deleteChannelMessages(channelId))
+                .thenReturn(Mono.empty());
 
         StepVerifier.create(chatService.deleteChannelMessages(channelId))
                 .expectError(RuntimeException.class)
                 .verify();
 
         verify(chatRepository, times(1)).deleteByChannelId(channelId);
+        verify(chatRedisRepository, times(1)).deleteChannelMessages(channelId);
     }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #47 

# 🔎 Key Changes
- rabbitmq, redis 추가
- 채팅 보낼 때, message queue에 넣고 cosumer가 dynamodb 저장/ 브로드캐스트/ redis 저장 작업을 수행
- RabbitMQ 패턴의 경우 Topic Exchange 패턴이 가장 적합하다고 판단되어 해당 패턴으로 구현했습니다. ( 와일드카드를 사용한 유연한 라우팅을 통해 메시지를 동적이고 세분화되게 분배할 수 있어, 복잡한 메시징 시나리오를 단순하고 확장 가능하게 처리 가능의 장점 보유)

<img width="797" alt="스크린샷 2024-12-23 오전 12 10 43" src="https://github.com/user-attachments/assets/7c902714-47bb-4a19-9e90-9690f277c6bc" />

# 💌 To Reviewers
- 주의사항
